### PR TITLE
feat(api): enhance Swagger documentation setup and add JSON endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 dist
 .env
+.vercel

--- a/src/docs/route.ts
+++ b/src/docs/route.ts
@@ -1,23 +1,34 @@
 import { Express } from "express";
 import swaggerUi from "swagger-ui-express";
 import swaggerOutput from "./swagger-output.json";
-import fs from "fs";
-import path from "path";
 
 export default (app: Express) => {
-  const css = fs.readFileSync(
-    path.resolve(
-      __dirname,
-      "../../node_modules/swagger-ui-dist/swagger-ui.css"
-    ),
-    "utf8"
-  );
+  // Setup Swagger dengan dokumentasi Zyvent API
+  const options = {
+    explorer: true,
+    customSiteTitle: "Zyvent API Documentation",
+    customCss: `
+      .swagger-ui .topbar { display: none }
+      .swagger-ui .info { margin: 50px 0 }
+      .swagger-ui .scheme-container { background: #fff; box-shadow: none; }
+    `,
+    swaggerOptions: {
+      // Gunakan data langsung dari swaggerOutput, bukan URL eksternal
+      spec: swaggerOutput,
+      supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+      docExpansion: 'list',
+      filter: true,
+      showRequestHeaders: true,
+    }
+  };
 
-  app.use(
-    "/api-docs",
-    swaggerUi.serve,
-    swaggerUi.setup(swaggerOutput, {
-      customCss: css,
-    })
-  );
+  app.use("/api-docs", swaggerUi.serve);
+  app.get("/api-docs", swaggerUi.setup(swaggerOutput, options));
+  
+  // JSON endpoint
+  app.get('/api-docs.json', (req, res) => {
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.send(swaggerOutput);
+  });
 };

--- a/vercel.json
+++ b/vercel.json
@@ -4,10 +4,28 @@
     {
       "src": "src/index.ts",
       "use": "@vercel/node",
-      "config": { "includeFiles": ["src/**"] }
+      "config": {
+        "includeFiles": ["node_modules/swagger-ui-dist/**"]
+      }
     }
   ],
   "routes": [
+    {
+      "src": "/api-docs/(.*\\.(css|js|png|jpg|jpeg|gif|ico|svg))$",
+      "dest": "src/index.ts"
+    },
+    {
+      "src": "/api-docs/?$",
+      "dest": "src/index.ts"
+    },
+    {
+      "src": "/api-docs.json", 
+      "dest": "src/index.ts"
+    },
+    {
+      "src": "/api/(.*)",
+      "dest": "src/index.ts"
+    },
     {
       "src": "/(.*)",
       "dest": "src/index.ts"


### PR DESCRIPTION
## Summary by Sourcery

Enhance the Swagger documentation setup by applying inline custom styling and explorer options, and expose a JSON endpoint for the raw API spec

New Features:
- Serve a customized Swagger UI at /api-docs with title, explorer, custom CSS, and swaggerOptions
- Add a JSON endpoint at /api-docs.json to return the swagger-output spec with CORS enabled

Enhancements:
- Remove external CSS file reading in favor of inline customCss in setup