### PR TITLE
feat(api): update Swagger documentation for authentication endpoints and responses

### DIFF
--- a/src/controllers/auth.controller.ts
+++ b/src/controllers/auth.controller.ts
@@ -15,7 +15,21 @@ interface AuthenticatedRequest extends Request {
 
 export default {
   register: async (req: Request, res: Response) => {
-    const { fullName, username, phoneNumber, email, password, role } =
+    /*
+      #swagger.summary = 'Register a new user'
+      #swagger.tags = ['Auth']
+      #swagger.requestBody = {
+        required: true,
+        schema: { $ref: "#/components/schemas/RegisterInput" }
+      }
+      #swagger.responses[201] = {
+        description: 'User registered successfully',
+        schema: { $ref: "#/components/schemas/RegisterResponse" }
+      }
+      #swagger.responses[400] = { description: 'Bad Request' }
+      #swagger.responses[500] = { description: 'Server Error' }
+    */
+    const { fullName, username, phoneNumber, email, password } =
       req.body as TRegister;
 
     try {
@@ -37,7 +51,7 @@ export default {
         phoneNumber,
         email,
         password: hashedPassword,
-        role: role || "user",
+        role: "user",
       });
 
       return res.status(201).json({
@@ -54,12 +68,18 @@ export default {
 
   login: async (req: Request, res: Response) => {
     /*
+      #swagger.summary = 'Login with email/username & password'
+      #swagger.tags = ['Auth']
       #swagger.requestBody = {
         required: true,
-        schema: {
-          $ref: "#/components/schemas/Login"
-        }
+        schema: { $ref: "#/components/schemas/LoginInput" }
       }
+      #swagger.responses[200] = {
+        description: 'Login successful',
+        schema: { $ref: "#/components/schemas/LoginResponse" }
+      }
+      #swagger.responses[400] = { description: 'Invalid credentials' }
+      #swagger.responses[500] = { description: 'Server Error' }
     */
     const { identifier, password } = req.body as TLogin;
 
@@ -87,7 +107,7 @@ export default {
 
       return res.status(200).json({
         message: "Login successful",
-        user: token,
+        token, 
       });
     } catch (err: any) {
       console.error("Login error:", err);
@@ -99,9 +119,17 @@ export default {
 
   profile: async (req: AuthenticatedRequest, res: Response) => {
     /*
+      #swagger.summary = 'Get logged in user profile'
+      #swagger.tags = ['Auth']
       #swagger.security = [{
         bearerAuth: []
       }]
+      #swagger.responses[200] = {
+        description: 'Profile retrieved successfully',
+        schema: { $ref: "#/components/schemas/ProfileResponse" }
+      }
+      #swagger.responses[404] = { description: 'User not found' }
+      #swagger.responses[500] = { description: 'Server Error' }
     */
     const userId = req.user?.id;
 

--- a/src/docs/swagger-output.json
+++ b/src/docs/swagger-output.json
@@ -38,43 +38,45 @@
     },
     "/v1/auth/register": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Register a new user",
         "description": "",
         "responses": {
           "201": {
-            "description": "Created"
+            "description": "User registered successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/RegisterResponse"
+                }
+              }
+            }
           },
           "400": {
             "description": "Bad Request"
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Server Error"
           }
         },
         "requestBody": {
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
-                "type": "object",
-                "properties": {
-                  "fullName": {
-                    "example": "any"
-                  },
-                  "username": {
-                    "example": "any"
-                  },
-                  "phoneNumber": {
-                    "example": "any"
-                  },
-                  "email": {
-                    "example": "any"
-                  },
-                  "password": {
-                    "example": "any"
-                  },
-                  "role": {
-                    "example": "any"
-                  }
-                }
+                "$ref": "#/components/schemas/RegisterInput"
+              }
+            },
+            "application/xml": {
+              "schema": {
+                "$ref": "#/components/schemas/RegisterInput"
               }
             }
           }
@@ -83,16 +85,32 @@
     },
     "/v1/auth/login": {
       "post": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Login with email/username & password",
         "description": "",
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Login successful",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/LoginResponse"
+                }
+              }
+            }
           },
           "400": {
-            "description": "Bad Request"
+            "description": "Invalid credentials"
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Server Error"
           }
         },
         "requestBody": {
@@ -100,12 +118,12 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/Login"
+                "$ref": "#/components/schemas/LoginInput"
               }
             },
             "application/xml": {
               "schema": {
-                "$ref": "#/components/schemas/Login"
+                "$ref": "#/components/schemas/LoginInput"
               }
             }
           }
@@ -114,6 +132,10 @@
     },
     "/v1/auth/profile": {
       "get": {
+        "tags": [
+          "Auth"
+        ],
+        "summary": "Get logged in user profile",
         "description": "",
         "parameters": [
           {
@@ -126,16 +148,28 @@
         ],
         "responses": {
           "200": {
-            "description": "OK"
+            "description": "Profile retrieved successfully",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              },
+              "application/xml": {
+                "schema": {
+                  "$ref": "#/components/schemas/ProfileResponse"
+                }
+              }
+            }
           },
           "401": {
             "description": "Unauthorized"
           },
           "404": {
-            "description": "Not Found"
+            "description": "User not found"
           },
           "500": {
-            "description": "Internal Server Error"
+            "description": "Server Error"
           }
         },
         "security": [
@@ -154,7 +188,71 @@
       }
     },
     "schemas": {
-      "Login": {
+      "User": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "string",
+            "example": "string"
+          },
+          "fullName": {
+            "type": "string",
+            "example": "string"
+          },
+          "username": {
+            "type": "string",
+            "example": "string"
+          },
+          "phoneNumber": {
+            "type": "string",
+            "example": "string"
+          },
+          "email": {
+            "type": "string",
+            "example": "string"
+          },
+          "role": {
+            "type": "string",
+            "example": "string"
+          }
+        },
+        "xml": {
+          "name": "User"
+        }
+      },
+      "RegisterInput": {
+        "type": "object",
+        "properties": {
+          "fullName": {
+            "type": "string",
+            "example": "string"
+          },
+          "username": {
+            "type": "string",
+            "example": "string"
+          },
+          "phoneNumber": {
+            "type": "string",
+            "example": "string"
+          },
+          "email": {
+            "type": "string",
+            "example": "string"
+          },
+          "password": {
+            "type": "string",
+            "example": "string"
+          },
+          "confirmPassword": {
+            "type": "string",
+            "example": "string"
+          }
+        },
+        "xml": {
+          "name": "RegisterInput"
+        }
+      },
+      "LoginInput": {
         "type": "object",
         "properties": {
           "identifier": {
@@ -167,7 +265,59 @@
           }
         },
         "xml": {
-          "name": "Login"
+          "name": "LoginInput"
+        }
+      },
+      "RegisterResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Registration successful"
+          },
+          "user": {
+            "xml": {
+              "name": "user"
+            },
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "xml": {
+          "name": "RegisterResponse"
+        }
+      },
+      "LoginResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Login successful"
+          },
+          "token": {
+            "type": "string",
+            "example": "string.jwt.token"
+          }
+        },
+        "xml": {
+          "name": "LoginResponse"
+        }
+      },
+      "ProfileResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string",
+            "example": "Profile retrieved successfully"
+          },
+          "user": {
+            "xml": {
+              "name": "user"
+            },
+            "$ref": "#/components/schemas/User"
+          }
+        },
+        "xml": {
+          "name": "ProfileResponse"
         }
       }
     }

--- a/src/docs/swagger.ts
+++ b/src/docs/swagger.ts
@@ -26,9 +26,38 @@ const doc = {
       },
     },
     schemas: {
-      Login: {
+      User: {
+        id: "string",
+        fullName: "string",
+        username: "string",
+        phoneNumber: "string",
+        email: "string",
+        role: "string",
+      },
+      RegisterInput: {
+        fullName: "string",
+        username: "string",
+        phoneNumber: "string",
+        email: "string",
+        password: "string",
+        confirmPassword: "string",
+      },
+      LoginInput: {
         identifier: "string",
         password: "string",
+      },
+
+      RegisterResponse: {
+        message: "Registration successful",
+        user: { $ref: "#/components/schemas/User" },
+      },
+      LoginResponse: {
+        message: "Login successful",
+        token: "string.jwt.token",
+      },
+      ProfileResponse: {
+        message: "Profile retrieved successfully",
+        user: { $ref: "#/components/schemas/User" },
       },
     },
   },


### PR DESCRIPTION
## Summary by Sourcery

Update Swagger documentation for authentication endpoints by adding detailed annotations, introduce structured request/response schemas, standardize default role assignment on registration, and adjust the login response payload.

Bug Fixes:
- Change login response to return 'token' field instead of 'user'

Enhancements:
- Add Swagger summaries, tags, requestBody, and response annotations for register, login, and profile endpoints
- Define new Swagger component schemas for User, RegisterInput, LoginInput, RegisterResponse, LoginResponse, and ProfileResponse
- Enforce default 'user' role assignment in registration

Documentation:
- Regenerate swagger-output.json to reflect updated documentation